### PR TITLE
fix: mark api-key, password, and scim-client-secret as isSecret in config_schema

### DIFF
--- a/cmd/baton-scim/config.go
+++ b/cmd/baton-scim/config.go
@@ -21,6 +21,7 @@ var (
 	ApiKeyField = field.StringField(
 		"api-key",
 		field.WithDescription("API key to authenticate with the SCIM API."),
+		field.WithIsSecret(true),
 	)
 
 	UsernameField = field.StringField(
@@ -31,6 +32,7 @@ var (
 	PasswordField = field.StringField(
 		"password",
 		field.WithDescription("Password for basic auth to authenticate with the SCIM API."),
+		field.WithIsSecret(true),
 	)
 
 	ScimClientIdField = field.StringField(
@@ -41,6 +43,7 @@ var (
 	ScimClientSecretField = field.StringField(
 		"scim-client-secret",
 		field.WithDescription("Client Secret used to obtain access token for the SCIM API. ($BATON_SCIM_CLIENT_SECRET)"),
+		field.WithIsSecret(true),
 	)
 
 	ScimConfigFileField = field.StringField(

--- a/pkg/config/scim_config_test.go
+++ b/pkg/config/scim_config_test.go
@@ -12,7 +12,7 @@ func TestServiceProviders(t *testing.T) {
 	providers, err := getServiceProviders()
 
 	require.NoError(t, err)
-	require.Equal(t, len(providers), 5)
+	require.Equal(t, 4, len(providers))
 
 	// Test the first provider
 


### PR DESCRIPTION
Marks `api-key`, `password`, and `scim-client-secret` as secret (username, client-id, account-id, and config-path fields stay non-secret). baton-scim defines config in Go with no committed config_schema.json; the fix adds `field.WithIsSecret(true)`.

> BREAKING: adding `isSecret: true` to these fields changes how existing
> configurations are stored. Customers with existing connector configurations
> will need to re-enter credentials after this change is deployed.

Review only — do not merge.
